### PR TITLE
Accept alternative ISO-3166-1-alpha2 codes for GB/UK and GR/EL

### DIFF
--- a/lib/json_vat.rb
+++ b/lib/json_vat.rb
@@ -38,7 +38,13 @@ module JSONVAT
     end
 
     def country(country)
-      self.rates.select { |r| r.country_code == country.to_s.upcase }.first
+      code = country.to_s.upcase
+
+      # Fix ISO-3166-1-alpha2 exceptions
+      if code == 'UK' then code = 'GB' end
+      if code == 'EL' then code = 'GR' end
+
+      self.rates.find { |r| r.country_code == code }
     end
 
     def [](country)
@@ -46,6 +52,5 @@ module JSONVAT
     end
 
   end
-
 
 end


### PR DESCRIPTION
As state here:

http://publications.europa.eu/code/en/en-370100.htm

> The names of the Member States of the European Union must always be written and abbreviated according to the following rules:
> - the two-letter ISO code should be used (ISO 3166 alpha-2), except for Greece and the United Kingdom, for which the abbreviations EL and UK are recommended;

However in current JSON document, Greece and UK can be found only as GR and GB.

In document which is [linked](http://ec.europa.eu/taxation_customs/resources/documents/taxation/vat/how_vat_works/rates/vat_rates_en.pdf) at Greece definition is used UK and EL instead of GB and GR. So I think JSONVAT client should handle those two exceptions.