### PR TITLE
Reset memoized rates when refreshing JSONVAT cache

### DIFF
--- a/lib/json_vat.rb
+++ b/lib/json_vat.rb
@@ -31,6 +31,7 @@ module JSONVAT
     def cache
       content = self.download
       self.cache_backend.write(content)
+      self.reset_rates
       content
     end
 
@@ -46,6 +47,10 @@ module JSONVAT
       @rates ||= JSON.parse(self.rates_through_cache)['rates'].map do |country|
         JSONVAT::Country.new(country)
       end
+    end
+
+    def reset_rates
+      @rates = nil
     end
 
     def country(country)


### PR DESCRIPTION
When calling `JSONVAT.cache` the rates collection isn't affected as it is memoized inside the `rates` method. I've added `reset_rates` which allows manual cleanup of memoized rates and it is also called from inside the `cache` method.