### PR TITLE
Rewrite to cleanly separate caching concern

### DIFF
--- a/lib/json_vat.rb
+++ b/lib/json_vat.rb
@@ -1,65 +1,79 @@
-require 'net/http'
-require 'uri'
-require 'json'
-require 'json_vat/country'
-require 'json_vat/file_cache_backend'
+require_relative 'json_vat/plain_client'
+require_relative 'json_vat/cached_client'
+require_relative 'json_vat/file_cache_backend'
 
 module JSONVAT
 
+  class Configuration
+
+    attr_accessor :perform_caching,
+                  :cache_backend,
+                  :host,
+                  :client
+
+    def initialize
+      @perform_caching = true
+      @cache_backend = FileCacheBackend.new('/tmp/jsonvat.json')
+      @host = 'http://jsonvat.com'
+      @client = nil
+    end
+  end
+
   class << self
 
-    def perform_caching?
-      @perform_caching != false
+    def configure
+      @configuration = Configuration.new
+      yield(configuration)
     end
 
-    def cache_backend
-      @cache_backend ||= FileCacheBackend.new
+    def configuration
+      @configuration ||= Configuration.new
     end
 
-    def host
-      @host ||= 'http://jsonvat.com'
+    def client
+      @client ||=
+        if configuration.client
+          configuration.client
+        elsif configuration.perform_caching
+          CachedClient.new(configuration.host, configuration.cache_backend)
+        else
+          PlainClient.new(configuration.host)
+        end
     end
 
-    attr_writer :cache_backend
-    attr_writer :perform_caching
-    attr_writer :host
+    attr_writer :client
+
+    # Deprecate old configuration methods
+    %w[cache_backend perform_caching host].each do |param|
+      define_method("#{param}=") do |val|
+        warn "[DEPRECATION] `JSONVAT.#{param}=` is deprecated. Please use `JSONVAT.configure` block instead."
+        configuration.send("#{param}=", val)
+      end
+    end
 
     def download
-      Net::HTTP.get_response(URI.parse(self.host)).body
+      client.download
     end
 
     def cache
-      content = self.download
-      self.cache_backend.write(content)
-      content
-    end
-
-    def rates_through_cache
-      if self.perform_caching?
-        self.cache_backend.read || self.cache
-      else
-        self.download
-      end
+      raise "#{client.class} does not support `cache` method" unless client.respond_to?(:cache)
+      client.cache
     end
 
     def rates
-      @rates ||= JSON.parse(self.rates_through_cache)['rates'].map do |country|
-        JSONVAT::Country.new(country)
-      end
+      client.rates
+    end
+
+    def reset_rates
+      client.reset_rates
     end
 
     def country(country)
-      code = country.to_s.upcase
-
-      # Fix ISO-3166-1-alpha2 exceptions
-      if code == 'UK' then code = 'GB' end
-      if code == 'EL' then code = 'GR' end
-
-      self.rates.find { |r| r.country_code == code }
+      client.country(country)
     end
 
     def [](country)
-      country(country)
+      client.country(country)
     end
 
   end

--- a/lib/json_vat/cached_client.rb
+++ b/lib/json_vat/cached_client.rb
@@ -1,0 +1,55 @@
+require_relative 'plain_client'
+
+module JSONVAT
+
+  # Class CachedClient reads data from the cache (file cache by default) and
+  # memoizes the result, cache has to be manually refreshed.
+  #
+  class CachedClient < PlainClient
+
+    def initialize(host = nil, cache_backend = nil)
+      super(host)
+      @cache_backend = cache_backend || JSONVAT.configuration.cache_backend
+      @cache_updated_at = cache_backend.updated_at
+    end
+
+    def data
+      JSON.parse(cache_read)
+    end
+
+    def rates
+      reset_rates unless cache_update?
+      super
+    end
+
+    def reset_rates
+      @cache_updated_at = cache_backend.updated_at
+      super
+    end
+
+    def cache
+      cache_refresh
+    end
+
+  private
+
+    attr_reader :cache_backend, :cache_updated_at
+
+    def cache_update?
+      cache_updated_at == cache_backend.updated_at
+    end
+
+    def cache_read
+      cache_backend.read || cache_refresh
+    end
+
+    def cache_refresh
+      content = download
+      cache_backend.write(content)
+      reset_rates
+      content
+    end
+
+  end
+
+end

--- a/lib/json_vat/file_cache_backend.rb
+++ b/lib/json_vat/file_cache_backend.rb
@@ -1,4 +1,8 @@
 module JSONVAT
+  # Class FileCacheBackend is file cache adapter for CachedClient.
+  #
+  # @attr [String] path The path to the cache file, default is "/tmp/jsonvat.json".
+  #
   class FileCacheBackend
 
     attr_accessor :path
@@ -7,14 +11,33 @@ module JSONVAT
       @path = path
     end
 
+    # Reads payload from the cache
+    #
+    # @return [String] The JSON payload
+    #
     def read
-      File.read(self.path)
+      File.read(path)
     rescue Errno::ENOENT
       nil
     end
 
+    # Writes payload to the cache
+    #
+    # @param [String] data The JSON payload
+    #
     def write(data)
-      File.open(self.path, 'w') { |f| f.write(data) }
+      File.open(path, 'w') { |f| f.write(data) }
+      nil
+    end
+
+    # Returns time of of the last update
+    #
+    # @return [Time,NilClass] The time of last update or nil
+    #
+    def updated_at
+      File.mtime(path)
+    rescue Errno::ENOENT
+      nil
     end
 
   end

--- a/lib/json_vat/plain_client.rb
+++ b/lib/json_vat/plain_client.rb
@@ -1,0 +1,52 @@
+require 'net/http'
+require 'uri'
+require 'json'
+require_relative 'country'
+
+module JSONVAT
+
+  class PlainClient
+
+    def initialize(host = nil)
+      @host = host || 'http://jsonvat.com'
+    end
+
+    def download
+      Net::HTTP.get_response(URI.parse(host)).body
+    end
+
+    def data
+      JSON.parse(download)
+    end
+
+    def rates
+      @rates ||= data['rates'].map do |country|
+        Country.new(country)
+      end
+    end
+
+    def reset_rates
+      @rates = nil
+    end
+
+    def country(country)
+      code = country.to_s.upcase
+
+      # Fix ISO-3166-1-alpha2 exceptions
+      if code == 'UK' then code = 'GB' end
+      if code == 'EL' then code = 'GR' end
+
+      rates.find { |r| r.country_code == code }
+    end
+
+    def [](country)
+      country(country)
+    end
+
+  protected
+
+    attr_reader :host
+
+  end
+
+end


### PR DESCRIPTION
With my findings in last PR https://github.com/adamcooke/json-vat/pull/7 caching invalidation needs more complex handling so I've decided to do a significant rewrite to extract `Configuration`, `PlainClient` and `CachedClient` from the procedural code inside the JSONVAT module as the resolving of the cache invalidation would add another bunch of IFs.

At first I've tried composition, but it leads to me to really complex solution which felt like overengineering so I ended-up with old fashioned inheritance approach.

The code should be compatible with the original API. But I've decided to deprecate configuration writers since I've added `configure` and `configuration` methods.

Now you can also use the client classes directly 

```
client = JSONVAT::CachedClient.new("my.host", MyCacheBackend.new)

JSONVAT.configure do |config| 
  config.client = JSONVAT::CachedClient.new("my.host", MyCacheBackend.new)
end
```

The code works I've run our in-app adapter tests against it successfully, but I feel it would be handy to add some tests or at least more documentation. So it should be considered as still in WIP.
