### PR TITLE
Allow different versions of the json gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source "https://rubygems.org"
-gem 'json'
+gem 'json', '>= 1.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    json (1.8.1)
+    json (2.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  json
+  json (>= 1.7.0)


### PR DESCRIPTION
Sometimes a project will be locked on a different JSON version, which makes it unable to bundle json-vat. This fixes that problem by allowing all versions above 1.7.0.