### PR TITLE
Relax JSON gem dependency.

### DIFF
--- a/json_vat.gemspec
+++ b/json_vat.gemspec
@@ -10,5 +10,5 @@ Gem::Specification.new do |s|
   s.summary     = "A client library for jsonvat.com"
   s.description = "Allows you to easily lookup VAT rats for EU countries based on the data from jsonvat.com."
   s.files = Dir["{lib}/**/*"]
-  s.add_dependency "json", "~> 1.7"
+  s.add_dependency "json", ">= 1.7"
 end


### PR DESCRIPTION
@adamcooke 

This changes the target version for `json` from `~> 1.7` to `>= 1.7`. I'm not sure if there was any particular reason to target a specific version, so I didn't remove it altogether. 

Thanks for your work on this gem!
Cheers.